### PR TITLE
feature: Don't check installation for use-package

### DIFF
--- a/lisp/jcs-package.el
+++ b/lisp/jcs-package.el
@@ -25,10 +25,6 @@
 ;; (@* "Packages" )
 ;;
 
-(unless (package-installed-p 'use-package)
-  (package-refresh-contents)
-  (package-install 'use-package))
-
 (setq use-package-always-defer t
       use-package-expand-minimally t)
 
@@ -323,7 +319,6 @@
           typescript-mode
           undo-tree-vf
           unfill
-          use-package
           use-ttf
           vc-refresh
           vertico-flx


### PR DESCRIPTION
According to https://git.savannah.gnu.org/cgit/emacs.git/commit/?h=emacs-29&id=e950f5a663ad3501e50f43ef6c0a7fd220e0c1f2, `use-package` is part of the Emacs core after 29.1.